### PR TITLE
Ability to search based on unreserved stock, plus translations for us

### DIFF
--- a/stock_available_unreserved/README.rst
+++ b/stock_available_unreserved/README.rst
@@ -48,6 +48,7 @@ Contributors
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
 * Stefan Rijnhart <stefan@opener.amsterdam>
 * Mykhailo Panarin <m.panarin@mobilunity.com>
+* Atte Isopuro <atte.isopuro@avoin.systems>
 
 
 Maintainer

--- a/stock_available_unreserved/i18n/stock_available_unreserved.pot
+++ b/stock_available_unreserved/i18n/stock_available_unreserved.pot
@@ -1,33 +1,29 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * stock_available_unreserved
+#	* stock_available_unreserved
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 11.0+e-20180401\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-09 12:28+0300\n"
-"PO-Revision-Date: 2018-04-09 12:34+0300\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
-"Language: fi\n"
+"POT-Creation-Date: 2018-04-09 09:27+0000\n"
+"PO-Revision-Date: 2018-04-09 09:27+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: stock_available_unreserved
 #: model:ir.model.fields,field_description:stock_available_unreserved.field_stock_quant_contains_unreserved
 msgid "Contains unreserved products"
-msgstr "Sisältää varaamattomia tuotteita"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.ui.view,arch_db:stock_available_unreserved.quant_search_view
 msgid "Internal Unreserved"
-msgstr "Sisäinen varaamaton"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: code:addons/stock_available_unreserved/models/product.py:116
@@ -44,22 +40,22 @@ msgstr ""
 #. module: stock_available_unreserved
 #: model:ir.model,name:stock_available_unreserved.model_product_product
 msgid "Product"
-msgstr "Tuote"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.model,name:stock_available_unreserved.model_product_template
 msgid "Product Template"
-msgstr "Tuotemalli"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.model.fields,field_description:stock_available_unreserved.field_product_product_qty_available_not_res
 msgid "Qty Available Not Reserved"
-msgstr "Varaamaton saldo"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.model.fields,field_description:stock_available_unreserved.field_product_template_qty_available_not_res
 msgid "Quantity On Hand Unreserved"
-msgstr "Varaamaton saldo"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.model,name:stock_available_unreserved.model_stock_quant
@@ -69,20 +65,21 @@ msgstr ""
 #. module: stock_available_unreserved
 #: model:ir.ui.view,arch_db:stock_available_unreserved.product_template_search_form_view_stock
 msgid "Reservable Products"
-msgstr "Varattavissa olevat tuotteet"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.actions.act_window,name:stock_available_unreserved.product_open_quants_unreserved
 msgid "Stock On Hand (Unreserved)"
-msgstr "Käytettävissä oleva (varaamaton) saldo"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.ui.view,arch_db:stock_available_unreserved.product_form_view_procurement_button
 #: model:ir.ui.view,arch_db:stock_available_unreserved.product_template_form_view_procurement_button
 msgid "Unreserved"
-msgstr "Varaamattomana"
+msgstr ""
 
 #. module: stock_available_unreserved
 #: model:ir.ui.view,arch_db:stock_available_unreserved.product_template_kanban_stock_view
 msgid "Unreserved:"
-msgstr "Varaamattomana:"
+msgstr ""
+

--- a/stock_available_unreserved/tests/test_stock_available_unreserved.py
+++ b/stock_available_unreserved/tests/test_stock_available_unreserved.py
@@ -43,6 +43,8 @@ class TestStockLogisticsWarehouse(SavepointCase):
             'uom_id': cls.uom_unit.id,
         })
 
+        cls.productC = cls.templateAB.product_variant_ids
+
         # Create product A and B
         cls.productA = cls.productObj.create({
             'name': 'product A',
@@ -175,3 +177,159 @@ class TestStockLogisticsWarehouse(SavepointCase):
              'product_id': self.productA.id,
              'quantity': 60.0})
         self.compare_qty_available_not_res(self.productA, 80)
+
+    def check_variants_found_correctly(self, operator, value, expected):
+        domain = [('id', 'in', self.templateAB.product_variant_ids.ids)]
+        return self.check_found_correctly(self.env['product.product'], domain, operator, value, expected)
+
+    def check_template_found_correctly(self, operator, value, expected):
+        # There may be other products already in the system: ignore those
+        domain = [('id', 'in', self.templateAB.ids)]
+        return self.check_found_correctly(self.env['product.template'], domain, operator, value, expected)
+
+    def check_found_correctly(self, model, domain, operator, value, expected):
+        found = model.search(domain + [
+            ('qty_available_not_res', operator, value)]
+        )
+        if found != expected:
+            self.fail("Searching for products failed: search for unreserved quantity "
+                      "{operator} {value}; expected to find {expected}, but found {found}".format(
+                operator=operator,
+                value=value,
+                expected=expected or "no products",
+                found=found,
+            ))
+
+    def test_stock_search(self):
+        all_variants = self.templateAB.product_variant_ids
+        a_and_b = self.productA + self.productB
+        b_and_c = self.productB + self.productC
+        a_and_c = self.productA + self.productC
+        no_variants = self.env['product.product']
+        no_template = self.env['product.template']
+        # Start: one template with three variants. All variants have zero unreserved stock
+        self.check_variants_found_correctly('=', 0, all_variants)
+        self.check_variants_found_correctly('>=', 0, all_variants)
+        self.check_variants_found_correctly('<=', 0, all_variants)
+        self.check_variants_found_correctly('>', 0, no_variants)
+        self.check_variants_found_correctly('<', 0, no_variants)
+        self.check_variants_found_correctly('!=', 0, no_variants)
+
+        self.check_template_found_correctly('=', 0, self.templateAB)
+        self.check_template_found_correctly('>=', 0, self.templateAB)
+        self.check_template_found_correctly('<=', 0, self.templateAB)
+        self.check_template_found_correctly('>', 0, no_template)
+        self.check_template_found_correctly('<', 0, no_template)
+        self.check_template_found_correctly('!=', 0, no_template)
+
+        self.pickingInA.action_confirm()
+        # All variants still have zero unreserved stock
+        self.check_variants_found_correctly('=', 0, all_variants)
+        self.check_variants_found_correctly('>=', 0, all_variants)
+        self.check_variants_found_correctly('<=', 0, all_variants)
+        self.check_variants_found_correctly('>', 0, no_variants)
+        self.check_variants_found_correctly('<', 0, no_variants)
+        self.check_variants_found_correctly('!=', 0, no_variants)
+
+        self.check_template_found_correctly('=', 0, self.templateAB)
+        self.check_template_found_correctly('>=', 0, self.templateAB)
+        self.check_template_found_correctly('<=', 0, self.templateAB)
+        self.check_template_found_correctly('>', 0, no_template)
+        self.check_template_found_correctly('<', 0, no_template)
+        self.check_template_found_correctly('!=', 0, no_template)
+
+        self.pickingInA.action_assign()
+        # All variants still have zero unreserved stock
+        self.check_variants_found_correctly('=', 0, all_variants)
+        self.check_variants_found_correctly('>=', 0, all_variants)
+        self.check_variants_found_correctly('<=', 0, all_variants)
+        self.check_variants_found_correctly('>', 0, no_variants)
+        self.check_variants_found_correctly('<', 0, no_variants)
+        self.check_variants_found_correctly('!=', 0, no_variants)
+
+        self.check_template_found_correctly('=', 0, self.templateAB)
+        self.check_template_found_correctly('>=', 0, self.templateAB)
+        self.check_template_found_correctly('<=', 0, self.templateAB)
+        self.check_template_found_correctly('>', 0, no_template)
+        self.check_template_found_correctly('<', 0, no_template)
+        self.check_template_found_correctly('!=', 0, no_template)
+
+        self.pickingInA.button_validate()
+        # product A has 2 unreserved stock, other variants have 0
+
+
+        self.check_variants_found_correctly('=', 2, self.productA)
+        self.check_variants_found_correctly('=', 0, b_and_c)
+        self.check_variants_found_correctly('>', 0, self.productA)
+        self.check_variants_found_correctly('<', 0, no_variants)
+        self.check_variants_found_correctly('!=', 0, self.productA)
+        self.check_variants_found_correctly('!=', 1, all_variants)
+        self.check_variants_found_correctly('!=', 2, b_and_c)
+        self.check_variants_found_correctly('<=', 0, b_and_c)
+        self.check_variants_found_correctly('<=', 1, b_and_c)
+        self.check_variants_found_correctly('>=', 0, all_variants)
+        self.check_variants_found_correctly('>=', 1, self.productA)
+
+        self.check_template_found_correctly('=', 0, self.templateAB)
+        self.check_template_found_correctly('=', 1, no_template)
+        self.check_template_found_correctly('=', 2, self.templateAB)
+        self.check_template_found_correctly('!=', 0, self.templateAB)
+        self.check_template_found_correctly('!=', 1, self.templateAB)
+        self.check_template_found_correctly('!=', 2, self.templateAB)
+        self.check_template_found_correctly('>', -1, self.templateAB)
+        self.check_template_found_correctly('>', 0, self.templateAB)
+        self.check_template_found_correctly('>', 1, self.templateAB)
+        self.check_template_found_correctly('>', 2, no_template)
+        self.check_template_found_correctly('<', 3, self.templateAB)
+        self.check_template_found_correctly('<', 2, self.templateAB)
+        self.check_template_found_correctly('<', 1, self.templateAB)
+        self.check_template_found_correctly('<', 0, no_template)
+        self.check_template_found_correctly('>=', 0, self.templateAB)
+        self.check_template_found_correctly('>=', 1, self.templateAB)
+        self.check_template_found_correctly('>=', 2, self.templateAB)
+        self.check_template_found_correctly('>=', 3, no_template)
+        self.check_template_found_correctly('<=', 3, self.templateAB)
+        self.check_template_found_correctly('<=', 2, self.templateAB)
+        self.check_template_found_correctly('<=', 1, self.templateAB)
+        self.check_template_found_correctly('<=', 0, self.templateAB)
+        self.check_template_found_correctly('<=', -1, no_template)
+
+
+        self.pickingInB.action_done()
+        # product A has 2 unreserved, product B has 3 unreserved and the remaining variant has 0
+
+        self.check_variants_found_correctly('=', 2, self.productA)
+        self.check_variants_found_correctly('=', 3, self.productB)
+        self.check_variants_found_correctly('=', 0, self.productC)
+        self.check_variants_found_correctly('>', 0, a_and_b)
+        self.check_variants_found_correctly('<', 0, no_variants)
+        self.check_variants_found_correctly('!=', 0, a_and_b)
+        self.check_variants_found_correctly('!=', 1, all_variants)
+        self.check_variants_found_correctly('!=', 2, b_and_c)
+        self.check_variants_found_correctly('!=', 3, a_and_c)
+        self.check_variants_found_correctly('<=', 0, self.productC)
+        self.check_variants_found_correctly('<=', 1, self.productC)
+        self.check_variants_found_correctly('>=', 0, all_variants)
+        self.check_variants_found_correctly('>=', 1, a_and_b)
+        self.check_variants_found_correctly('>=', 2, a_and_b)
+        self.check_variants_found_correctly('>=', 3, self.productB)
+        self.check_variants_found_correctly('>=', 4, no_variants)
+
+        self.check_template_found_correctly('=', 0, self.templateAB)
+        self.check_template_found_correctly('=', 1, no_template)
+        self.check_template_found_correctly('=', 2, self.templateAB)
+        self.check_template_found_correctly('=', 3, self.templateAB)
+        self.check_template_found_correctly('!=', 0, self.templateAB)
+        self.check_template_found_correctly('!=', 2, self.templateAB)
+        self.check_template_found_correctly('!=', 3, self.templateAB)
+        self.check_template_found_correctly('>', 1, self.templateAB)
+        self.check_template_found_correctly('>', 2, self.templateAB)
+        # This part may seem a bit unintuitive, but this is the way it works in the Odoo core
+        # Searches are "deferred" to the variants, so while the template says it has a stock of 5,
+        # searching for a stock greater than 3 will not find anything because no singular variant
+        # has a higher stock
+        self.check_template_found_correctly('>', 3, no_template)
+        self.check_template_found_correctly('<', 3, self.templateAB)
+        self.check_template_found_correctly('<', 2, self.templateAB)
+        self.check_template_found_correctly('<', 1, self.templateAB)
+        self.check_template_found_correctly('<', 0, no_template)

--- a/stock_available_unreserved/views/product_view.xml
+++ b/stock_available_unreserved/views/product_view.xml
@@ -14,6 +14,17 @@
             </field>
         </record>
 
+        <record id="product_template_search_form_view_stock" model="ir.ui.view">
+            <field name="name">product.template.search.stock.form.inherit</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="stock.product_template_search_form_view_stock"/>
+            <field name="arch" type="xml">
+                <filter name="real_stock_available" position="after">
+                    <filter name="real_stock_unreserved" string="Reservable Products" domain="[('qty_available_not_res','&gt;',0)]"/>
+                </filter>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="product_template_kanban_stock_view">
             <field name="name">Product Template Kanban Stock</field>
             <field name="model">product.template</field>


### PR DESCRIPTION
Add ability to search products based on unreserved stock, same as can be done for the core quantity fields. 

*This PR includes translations, which should not be merged into OCA*. They use Transifex. But we need this translation quickly, so we can't wait for them to accept this PR and to sync Transifex. Once this PR is accepted, a separate PR should be opened for `imp-allow-search` to their `11.0`. Then once (if) that is accepted, we should update the Finnish translation in transifex.